### PR TITLE
feat: add logo and image handling for cloned stores and sections

### DIFF
--- a/app/controllers/spree/olitt/clone_store/clone_store_controller.rb
+++ b/app/controllers/spree/olitt/clone_store/clone_store_controller.rb
@@ -141,6 +141,9 @@ module Spree
           end
 
           store = clone_and_update_store @old_store.dup
+          store.build_logo
+          store.build_mailer_logo
+          store.build_favicon_image
           store.logo.attach(@old_store.logo.attachment.blob) if @old_store&.logo&.attachment&.attached?
           store.mailer_logo.attach(@old_store.mailer_logo.attachment.blob) if @old_store&.mailer_logo&.attachment&.attached?
           store.favicon_image.attach(@old_store.favicon_image.attachment.blob) if @old_store&.favicon_image&.attachment&.attached?

--- a/app/controllers/spree/olitt/clone_store/duplicators/sections_duplicator.rb
+++ b/app/controllers/spree/olitt/clone_store/duplicators/sections_duplicator.rb
@@ -31,6 +31,9 @@ module Spree
           end
 
           def duplicate_images(new_section:, old_section:)
+            new_section.build_image_one
+            new_section.build_image_two
+            new_section.build_image_three
             new_section.image_one.attach(old_section.image_one.attachment.blob) unless old_section.image_one.nil?
             new_section.image_two.attach(old_section.image_two.attachment.blob) unless old_section.image_two.nil?
             new_section.image_three.attach(old_section.image_three.attachment.blob) unless old_section.image_three.nil?


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added handling for building logo, mailer logo, and favicon images during store cloning.

- Enhanced duplication of sections to include building and attaching multiple images.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clone_store_controller.rb</strong><dd><code>Add image building and attachment for cloned stores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/spree/olitt/clone_store/clone_store_controller.rb

<li>Added methods to build logo, mailer logo, and favicon images.<br> <li> Ensured attachments for logo, mailer logo, and favicon images are <br>cloned.


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/spree-clone-store/pull/10/files#diff-9222144b958674b6eab34baa37702f94eb027589b723f2647690c7e246bba14a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sections_duplicator.rb</strong><dd><code>Enhance section duplication with image handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/spree/olitt/clone_store/duplicators/sections_duplicator.rb

<li>Added methods to build three images for sections.<br> <li> Enhanced duplication process to attach images from old sections.


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/spree-clone-store/pull/10/files#diff-81cd36378b24b8702111e0ab41d5babee964b1efeec29e09ef6003276109d175">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>