### PR TITLE
fix: streamline logo and image attachment handling in clone store pro…

### DIFF
--- a/app/controllers/spree/olitt/clone_store/clone_store_controller.rb
+++ b/app/controllers/spree/olitt/clone_store/clone_store_controller.rb
@@ -141,12 +141,8 @@ module Spree
           end
 
           store = clone_and_update_store @old_store.dup
-          store.build_logo if @old_store&.logo&.attachment&.attached?
-          store.build_mailer_logo if @old_store&.mailer_logo&.attachment&.attached?
-          store.build_favicon_image if @old_store&.favicon_image&.attachment&.attached?
           store.logo.attachment.attach(@old_store.logo.attachment.blob) if @old_store&.logo&.attachment&.attached?
           store.mailer_logo.attachment.attach(@old_store.mailer_logo.attachment.blob) if @old_store&.mailer_logo&.attachment&.attached?
-          store.favicon_image.attachment.attach(@old_store.favicon_image.attachment.blob) if @old_store&.favicon_image&.attachment&.attached?
 
           unless store.save
             render_error_payload(store.errors)


### PR DESCRIPTION
### **User description**
…cess


___

### **PR Type**
Bug fix


___

### **Description**
- Streamlined handling of logo and image attachments in store cloning.

- Removed redundant `build_*` calls for store images.

- Ensured direct attachment of image blobs during cloning.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clone_store_controller.rb</strong><dd><code>Simplify image attachment logic in store cloning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/spree/olitt/clone_store/clone_store_controller.rb

<li>Removed redundant <code>build_*</code> calls for logo, mailer logo, and favicon <br>image.<br> <li> Simplified image attachment logic by directly attaching blobs.<br> <li> Improved code clarity and reduced unnecessary operations.


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/spree-clone-store/pull/13/files#diff-9222144b958674b6eab34baa37702f94eb027589b723f2647690c7e246bba14a">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>