### PR TITLE
feat: Implement stock locations and vendor addresses duplicators

### DIFF
--- a/app/helpers/spree/olitt/clone_store/product_helpers.rb
+++ b/app/helpers/spree/olitt/clone_store/product_helpers.rb
@@ -2,28 +2,61 @@ module Spree
   module Olitt
     module CloneStore
       module ProductHelpers
-        def duplicate_master_variant(product:, vendor_id:, code:)
+        def duplicate_master_variant(product:, vendor_id:, code:, tax_category: nil)
           master = product.master
           master.dup.tap do |new_master|
             new_master.sku = sku_generator(sku: master.sku, code: code)
             new_master.deleted_at = nil
             new_master.vendor_id = vendor_id
-            new_master.images = master.images.map { |image| duplicate_image(image: image) }
-            new_master.price = master.price
-            new_master.currency = master.currency
+            new_master.tax_category = tax_category if new_master.respond_to?(:tax_category=)
+            assign_variant_assets(new_variant: new_master, old_variant: master)
           end
         end
 
-        def duplicate_variant(variant:, vendor_id:, code:)
-          option_values = variant.option_values.to_a.compact
+        def duplicate_variant(variant:, vendor_id:, code:, option_values: nil, tax_category: nil)
+          option_values = Array(option_values.presence || variant.option_values.to_a.compact).compact
           return if option_values.empty?
 
           new_variant = variant.dup
           new_variant.sku = sku_generator(sku: variant.sku, code: code)
           new_variant.deleted_at = nil
           new_variant.vendor_id = vendor_id
+          new_variant.tax_category = tax_category if new_variant.respond_to?(:tax_category=)
           new_variant.option_values = option_values
+          assign_variant_assets(new_variant: new_variant, old_variant: variant)
           new_variant
+        end
+
+        def assign_variant_assets(new_variant:, old_variant:)
+          new_variant.images = duplicate_images(images: old_variant.images) if new_variant.respond_to?(:images=)
+          assign_variant_prices(new_variant: new_variant, old_variant: old_variant)
+        end
+
+        def duplicate_images(images:)
+          Array(images).map { |image| duplicate_image(image: image) }
+        end
+
+        def assign_variant_prices(new_variant:, old_variant:)
+          prices = duplicate_prices(prices: old_variant.prices)
+
+          if prices.any? && new_variant.respond_to?(:prices=)
+            new_variant.prices = prices
+          elsif old_variant.respond_to?(:price) && new_variant.respond_to?(:price=)
+            new_variant.price = old_variant.price
+            new_variant.currency = old_variant.currency if new_variant.respond_to?(:currency=) && old_variant.respond_to?(:currency)
+          end
+        end
+
+        def duplicate_prices(prices:)
+          Array(prices).filter_map do |price|
+            next if price.blank?
+
+            price.dup.tap do |new_price|
+              new_price.deleted_at = nil if new_price.respond_to?(:deleted_at=)
+              new_price.created_at = nil if new_price.respond_to?(:created_at=)
+              new_price.updated_at = nil if new_price.respond_to?(:updated_at=)
+            end
+          end
         end
 
         def duplicate_image(image:)

--- a/app/services/spree/olitt/clone_store/duplicators/option_types_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/option_types_duplicator.rb
@@ -1,0 +1,107 @@
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        class OptionTypesDuplicator < BaseDuplicator
+          attr_reader :option_types_cache, :option_values_cache
+
+          def initialize(old_store:, new_store:, vendor:)
+            super()
+            @old_store = old_store
+            @new_store = new_store
+            @vendor = vendor
+            @option_types_cache = {}
+            @option_values_cache = {}
+          end
+
+          def handle_clone_option_types
+            source_option_types.each do |option_type|
+              clone_option_type(option_type)
+            rescue StandardError => e
+              record_errors([e.message], context: "option type #{option_type.id}")
+            end
+          end
+
+          private
+
+          def source_option_types
+            @source_option_types ||= @old_store.products.includes(option_types: :option_values).flat_map(&:option_types).compact.uniq(&:id)
+          end
+
+          def clone_option_type(option_type)
+            new_option_type = find_or_initialize_option_type(option_type: option_type)
+            assign_vendor(model_instance: new_option_type, vendor: @vendor)
+            assign_option_type_attributes(new_option_type: new_option_type, option_type: option_type)
+            saved = save_model(model_instance: new_option_type, context: "option type #{option_type.id}")
+            return unless saved
+
+            cache_option_type(old_option_type: option_type, new_option_type: new_option_type)
+            clone_option_values(old_option_type: option_type, new_option_type: new_option_type)
+          end
+
+          def find_or_initialize_option_type(option_type:)
+            option_type_for_vendor(option_type: option_type) || Spree::OptionType.new
+          end
+
+          def option_type_for_vendor(option_type:)
+            return unless option_type.vendor_id == @vendor.id
+
+            Spree::OptionType.find_by(id: option_type.id)
+          end
+
+          def assign_option_type_attributes(new_option_type:, option_type:)
+            new_option_type.name = unique_option_type_name(option_type: option_type, new_option_type: new_option_type)
+            new_option_type.presentation = option_type.presentation
+            new_option_type.position = option_type.position
+            new_option_type.filterable = option_type.filterable
+            new_option_type.public_metadata = option_type.public_metadata if new_option_type.respond_to?(:public_metadata=)
+            new_option_type.private_metadata = option_type.private_metadata if new_option_type.respond_to?(:private_metadata=)
+          end
+
+          def clone_option_values(old_option_type:, new_option_type:)
+            old_option_type.option_values.each do |option_value|
+              new_option_value = find_or_initialize_option_value(new_option_type: new_option_type, option_value: option_value)
+              assign_vendor(model_instance: new_option_value, vendor: @vendor)
+              new_option_value.option_type = new_option_type
+              new_option_value.name = option_value.name
+              new_option_value.presentation = option_value.presentation
+              new_option_value.position = option_value.position
+              new_option_value.public_metadata = option_value.public_metadata if new_option_value.respond_to?(:public_metadata=)
+              new_option_value.private_metadata = option_value.private_metadata if new_option_value.respond_to?(:private_metadata=)
+              saved = save_model(model_instance: new_option_value, context: "option value #{option_value.id}")
+              next unless saved
+
+              cache_option_value(old_option_value: option_value, new_option_value: new_option_value)
+            rescue StandardError => e
+              record_errors([e.message], context: "option value #{option_value.id}")
+            end
+          end
+
+          def find_or_initialize_option_value(new_option_type:, option_value:)
+            new_option_type.option_values.find_by(name: option_value.name) || Spree::OptionValue.new
+          end
+
+          def cache_option_type(old_option_type:, new_option_type:)
+            @option_types_cache[old_option_type.id] = [new_option_type]
+          end
+
+          def cache_option_value(old_option_value:, new_option_value:)
+            @option_values_cache[old_option_value.id] = [new_option_value]
+          end
+
+          def unique_option_type_name(option_type:, new_option_type:)
+            base_name = if option_type.vendor_id == @vendor.id
+                          option_type.name
+                        else
+                          [option_type.name, @new_store.code.presence].compact.join('_')
+                        end
+
+            unique_value(base_value: base_name, separator: '_', max_length: 100) do |candidate|
+              Spree::OptionType.where.not(id: new_option_type.id).where(name: candidate).exists?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/spree/olitt/clone_store/duplicators/payment_methods_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/payment_methods_duplicator.rb
@@ -3,30 +3,80 @@ module Spree
     module CloneStore
       module Duplicators
         class PaymentMethodsDuplicator < BaseDuplicator
-          def initialize(new_store:, vendor:)
+          def initialize(old_store:, new_store:, vendor:)
             super()
+            @old_store = old_store
             @new_store = new_store
             @vendor = vendor
           end
 
           def duplicate
-            # Get clone payment method from environment
-            if ENV['CLONE_PAYMENT_METHODS_IDS'].present?
-              payment_methods_ids = ENV['CLONE_PAYMENT_METHODS_IDS'].split(',')
-              payment_methods_ids.each do |payment_method_id|
-                payment_method = Spree::PaymentMethod.find(payment_method_id)
-                if payment_method.present?
-                  new_payment_method = payment_method.dup
-                  new_payment_method.stores = [@new_store]
-                  assign_vendor(model_instance: new_payment_method, vendor: @vendor)
-                  new_payment_method.created_at = Time.zone.now
-                  new_payment_method.updated_at = nil
-                  save_model(model_instance: new_payment_method, context: "payment method #{payment_method_id}")
-                end
-              rescue StandardError => e
-                record_errors([e.message], context: "payment method #{payment_method_id}")
-              end
+            source_payment_methods.each do |payment_method|
+              next if payment_method.blank?
+
+              new_payment_method = existing_payment_method(payment_method: payment_method) || payment_method.dup
+              assign_vendor(model_instance: new_payment_method, vendor: @vendor)
+              assign_payment_method_attributes(new_payment_method: new_payment_method, payment_method: payment_method)
+              new_payment_method.stores = [@new_store]
+              new_payment_method.created_at = nil if new_payment_method.respond_to?(:created_at=)
+              new_payment_method.updated_at = nil if new_payment_method.respond_to?(:updated_at=)
+              new_payment_method.deleted_at = nil if new_payment_method.respond_to?(:deleted_at=)
+              save_model(model_instance: new_payment_method, context: "payment method #{payment_method.id}")
+            rescue StandardError => e
+              record_errors([e.message], context: "payment method #{payment_method.id}")
             end
+          end
+
+          private
+
+          def source_payment_methods
+            source_methods = source_store_payment_methods
+            return source_methods if source_methods.present?
+
+            fallback_payment_methods
+          end
+
+          def source_store_payment_methods
+            return [] unless @old_store.respond_to?(:payment_methods)
+
+            payment_methods = @old_store.payment_methods.includes(:stores).to_a
+            return payment_methods if source_vendor.blank?
+
+            payment_methods.select do |payment_method|
+              payment_method.respond_to?(:vendor_id) && [source_vendor.id, nil].include?(payment_method.vendor_id)
+            end
+          end
+
+          def source_vendor
+            return @source_vendor if defined?(@source_vendor)
+
+            @source_vendor = @old_store.respond_to?(:vendor) ? @old_store.vendor : nil
+          end
+
+          def fallback_payment_methods
+            payment_methods_ids = ENV['CLONE_PAYMENT_METHODS_IDS'].to_s.split(',').map(&:strip).reject(&:blank?)
+            return [] if payment_methods_ids.empty?
+
+            Spree::PaymentMethod.where(id: payment_methods_ids).includes(:stores).to_a
+          end
+
+          def existing_payment_method(payment_method:)
+            Spree::PaymentMethod.joins(:stores).find_by(
+              vendor_id: @vendor.id,
+              type: payment_method.type,
+              name: payment_method.name,
+              spree_stores: { id: @new_store.id }
+            )
+          end
+
+          def assign_payment_method_attributes(new_payment_method:, payment_method:)
+            new_payment_method.name = payment_method.name
+            new_payment_method.description = payment_method.description if new_payment_method.respond_to?(:description=)
+            new_payment_method.active = payment_method.active if new_payment_method.respond_to?(:active=)
+            new_payment_method.display_on = payment_method.display_on if new_payment_method.respond_to?(:display_on=)
+            new_payment_method.auto_capture = payment_method.auto_capture if new_payment_method.respond_to?(:auto_capture=)
+            new_payment_method.position = payment_method.position if new_payment_method.respond_to?(:position=) && payment_method.respond_to?(:position)
+            new_payment_method.public_metadata = payment_method.public_metadata.deep_dup if new_payment_method.respond_to?(:public_metadata=) && payment_method.respond_to?(:public_metadata)
           end
         end
       end

--- a/app/services/spree/olitt/clone_store/duplicators/products_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/products_duplicator.rb
@@ -3,23 +3,35 @@ module Spree
     module CloneStore
       module Duplicators
         class ProductsDuplicator < BaseDuplicator
-          attr_reader :products_cache
+          attr_reader :products_cache, :variants_cache
 
           include Spree::Olitt::CloneStore::ProductHelpers
 
-          def initialize(old_store:, new_store:, vendor:, taxon_cache:)
+          def initialize(old_store:, new_store:, vendor:, taxon_cache:, shipping_category_cache: {}, option_type_cache: {}, option_value_cache: {})
             super()
             @old_store = old_store
             @new_store = new_store
             @vendor = vendor
             @taxon_cache = taxon_cache
+            @shipping_category_cache = shipping_category_cache
+            @option_type_cache = option_type_cache
+            @option_value_cache = option_value_cache
             @limit = ENV['PRODUCTS_CLONE_LIMIT']&.to_i || 20
 
             @products_cache = {}
+            @variants_cache = {}
           end
 
           def handle_clone_products
-            old_products = @old_store.products.includes(:product_properties, :taxons, { variants: :option_values }, master: %i[images default_price]).limit(@limit)
+            old_products = @old_store.products.includes(
+              :shipping_category,
+              :tax_category,
+              :product_properties,
+              :taxons,
+              { product_option_types: :option_type },
+              { variants: [:images, :prices, :tax_category, { option_values: :option_type }] },
+              master: %i[images prices default_price tax_category]
+            ).limit(@limit)
             old_products.each do |old_product|
               save_product(old_product: old_product)
             rescue StandardError => e
@@ -33,29 +45,81 @@ module Spree
             new_product = reset_timestamps(product: new_product)
             new_product.slug = build_cloned_slug(old_product: old_product)
             new_product.taxons = get_new_taxons(old_product: old_product)
+            new_product.tax_category = resolve_tax_category(old_product.tax_category)
+            new_product.shipping_category = get_new_shipping_category(old_product: old_product)
             new_product.vendor_id = @vendor.id
+            new_product.product_option_types = reset_product_option_types(product: old_product)
             new_product.variants = get_new_variants(old_product: old_product)
-            new_product.master = duplicate_master_variant(product: old_product, vendor_id: @vendor.id, code: @new_store.code)
+            new_product.master = duplicate_master_variant(
+              product: old_product,
+              vendor_id: @vendor.id,
+              code: @new_store.code,
+              tax_category: resolve_tax_category(old_product.master&.tax_category)
+            )
             new_product.product_properties = reset_properties(product: old_product)
             saved = save_model(model_instance: new_product, context: "product #{old_product.id}")
             return unless saved
 
             @products_cache[old_product.slug] = [new_product]
+            cache_variants(old_product: old_product, new_product: new_product)
           end
 
           def get_new_taxons(old_product:)
             old_product.taxons.map { |old_taxon| @taxon_cache[old_taxon.permalink]&.first }.compact
           end
 
+          def get_new_shipping_category(old_product:)
+            old_shipping_category = old_product.shipping_category
+            return if old_shipping_category.blank?
+
+            @shipping_category_cache[old_shipping_category.id]&.first ||
+              @shipping_category_cache[old_shipping_category.name]&.first ||
+              old_shipping_category
+          end
+
           def get_new_variants(old_product:)
             old_product.variants.filter_map do |variant|
-              new_variant = duplicate_variant(variant: variant, vendor_id: @vendor.id, code: @new_store.code)
+              new_variant = duplicate_variant(
+                variant: variant,
+                vendor_id: @vendor.id,
+                code: @new_store.code,
+                option_values: get_new_option_values(variant: variant),
+                tax_category: resolve_tax_category(variant.tax_category)
+              )
               next new_variant if new_variant.present?
 
               Rails.logger.warn(
                 "[spree_clone_store] Skipping variant #{variant.id} for product #{old_product.id} because it has no option values"
               )
               nil
+            end
+          end
+
+          def get_new_option_values(variant:)
+            variant.option_values.map { |option_value| @option_value_cache[option_value.id]&.first }.compact
+          end
+
+          def reset_product_option_types(product:)
+            product.product_option_types.filter_map do |product_option_type|
+              option_type = @option_type_cache[product_option_type.option_type_id]&.first
+              next if option_type.blank?
+
+              new_product_option_type = product_option_type.dup
+              new_product_option_type.option_type = option_type
+              new_product_option_type.created_at = nil
+              new_product_option_type.updated_at = nil
+              new_product_option_type
+            end
+          end
+
+          def cache_variants(old_product:, new_product:)
+            @variants_cache[old_product.master.id] = [new_product.master] if old_product.master.present? && new_product.master.present?
+
+            old_product.variants.each_with_index do |old_variant, index|
+              new_variant = new_product.variants[index]
+              next if new_variant.blank?
+
+              @variants_cache[old_variant.id] = [new_variant]
             end
           end
 
@@ -70,6 +134,31 @@ module Spree
             return @new_store.code if old_product.slug.blank?
 
             "#{old_product.slug}-#{@new_store.code}"
+          end
+
+          def resolve_tax_category(old_tax_category)
+            return if old_tax_category.blank?
+
+            @tax_category_cache ||= {}
+            @tax_category_cache[old_tax_category.id] ||= begin
+              Spree::TaxCategory.find_by(id: old_tax_category.id) ||
+                Spree::TaxCategory.find_by(name: old_tax_category.name) ||
+                find_tax_category_by_tax_code(old_tax_category: old_tax_category) ||
+                default_tax_category(old_tax_category: old_tax_category) ||
+                old_tax_category
+            end
+          end
+
+          def find_tax_category_by_tax_code(old_tax_category:)
+            return if old_tax_category.tax_code.blank?
+
+            Spree::TaxCategory.find_by(tax_code: old_tax_category.tax_code)
+          end
+
+          def default_tax_category(old_tax_category:)
+            return unless old_tax_category.respond_to?(:is_default?) && old_tax_category.is_default?
+
+            Spree::TaxCategory.default
           end
         end
       end

--- a/app/services/spree/olitt/clone_store/duplicators/shipping_categories_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/shipping_categories_duplicator.rb
@@ -1,0 +1,75 @@
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        class ShippingCategoriesDuplicator < BaseDuplicator
+          attr_reader :shipping_categories_cache
+
+          def initialize(old_store:, new_store:, vendor:)
+            super()
+            @old_store = old_store
+            @new_store = new_store
+            @vendor = vendor
+            @shipping_categories_cache = {}
+          end
+
+          def handle_clone_shipping_categories
+            source_shipping_categories.each do |shipping_category|
+              clone_shipping_category(shipping_category)
+            rescue StandardError => e
+              record_errors([e.message], context: "shipping category #{shipping_category.id}")
+            end
+          end
+
+          private
+
+          def source_shipping_categories
+            categories_from_products = @old_store.products.includes(:shipping_category).map(&:shipping_category)
+            categories_from_methods = if source_vendor.present?
+                                        source_vendor.shipping_methods.includes(:shipping_categories).flat_map(&:shipping_categories)
+                                      else
+                                        []
+                                      end
+
+            (categories_from_products + categories_from_methods).compact.uniq(&:id)
+          end
+
+          def source_vendor
+            return @source_vendor if defined?(@source_vendor)
+
+            @source_vendor = @old_store.respond_to?(:vendor) ? @old_store.vendor : nil
+          end
+
+          def clone_shipping_category(shipping_category)
+            new_shipping_category = find_or_initialize_shipping_category(shipping_category: shipping_category)
+            assign_vendor(model_instance: new_shipping_category, vendor: @vendor)
+            new_shipping_category.name = unique_shipping_category_name(shipping_category: shipping_category, new_shipping_category: new_shipping_category)
+            saved = save_model(model_instance: new_shipping_category, context: "shipping category #{shipping_category.id}")
+            return unless saved
+
+            cache_shipping_category(old_shipping_category: shipping_category, new_shipping_category: new_shipping_category)
+          end
+
+          def find_or_initialize_shipping_category(shipping_category:)
+            vendor_shipping_categories.find_by(name: shipping_category.name) || Spree::ShippingCategory.new
+          end
+
+          def cache_shipping_category(old_shipping_category:, new_shipping_category:)
+            @shipping_categories_cache[old_shipping_category.id] = [new_shipping_category]
+            @shipping_categories_cache[old_shipping_category.name] = [new_shipping_category]
+          end
+
+          def unique_shipping_category_name(shipping_category:, new_shipping_category:)
+            unique_value(base_value: shipping_category.name) do |candidate|
+              vendor_shipping_categories.where.not(id: new_shipping_category.id).where(name: candidate).exists?
+            end
+          end
+
+          def vendor_shipping_categories
+            Spree::ShippingCategory.where(vendor_id: @vendor.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/spree/olitt/clone_store/duplicators/shipping_methods_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/shipping_methods_duplicator.rb
@@ -3,43 +3,103 @@ module Spree
     module CloneStore
       module Duplicators
         class ShippingMethodsDuplicator < BaseDuplicator
-          def initialize(vendor:, new_store:)
+          def initialize(old_store:, vendor:, new_store:, shipping_categories_cache: {}, zone_resolver: nil)
             super()
+            @old_store = old_store
             @vendor = vendor
             @new_store = new_store
+            @shipping_categories_cache = shipping_categories_cache
+            @zone_resolver = zone_resolver || ZoneResolver.new
           end
 
           def duplicate
-            # Get clone shipping methods from environment
-            vendor_shipping_methods = @vendor.shipping_methods.all
-            if ENV['CLONE_SHIPPING_METHODS_IDS'].present? && (vendor_shipping_methods.count == 0)
-              shipping_methods_ids = ENV['CLONE_SHIPPING_METHODS_IDS'].split(',')
-              shipping_methods_ids.each do |shipping_method_id|
-                shipping_method = Spree::ShippingMethod.find(shipping_method_id)
-                if shipping_method.present?
-                  new_shipping_method = shipping_method.dup
-                  assign_vendor(model_instance: new_shipping_method, vendor: @vendor)
-                  new_shipping_method.shipping_categories = shipping_method.shipping_categories.all
-                  new_shipping_method.calculator = duplicate_calculator(shipping_method.calculator)
-                  new_shipping_method.name = "#{shipping_method.name} - #{@new_store.name}"
-                  new_shipping_method.zones = shipping_method.zones.all
-                  new_shipping_method.created_at = Time.zone.now
-                  new_shipping_method.updated_at = nil
-                  save_model(model_instance: new_shipping_method, context: "shipping method #{shipping_method_id}")
-                end
-              rescue StandardError => e
-                record_errors([e.message], context: "shipping method #{shipping_method_id}")
-              end
+            source_shipping_methods.find_each do |shipping_method|
+              clone_shipping_method(shipping_method)
+            rescue StandardError => e
+              record_errors([e.message], context: "shipping method #{shipping_method.id}")
             end
           end
-          def duplicate_calculator(calculator)
-            if calculator.present?
-              new_calculator = calculator.dup
-              new_calculator.created_at = Time.zone.now
-              new_calculator.updated_at = nil
-              new_calculator.save
-              new_calculator
+
+          private
+
+          def source_shipping_methods
+            return fallback_shipping_methods if source_vendor.blank?
+
+            source_vendor.shipping_methods.includes(:shipping_categories, :zones, :calculator)
+          end
+
+          def source_vendor
+            return @source_vendor if defined?(@source_vendor)
+
+            @source_vendor = @old_store.respond_to?(:vendor) ? @old_store.vendor : nil
+          end
+
+          def fallback_shipping_methods
+            ids = ENV['CLONE_SHIPPING_METHODS_IDS'].to_s.split(',').map(&:strip).reject(&:blank?)
+            Spree::ShippingMethod.where(id: ids).includes(:shipping_categories, :zones, :calculator)
+          end
+
+          def clone_shipping_method(shipping_method)
+            new_shipping_method = find_or_initialize_shipping_method(shipping_method: shipping_method)
+            assign_vendor(model_instance: new_shipping_method, vendor: @vendor)
+            assign_shipping_method_attributes(new_shipping_method: new_shipping_method, shipping_method: shipping_method)
+            new_shipping_method.shipping_categories = remapped_shipping_categories(shipping_method: shipping_method)
+            new_shipping_method.zones = resolved_zones(shipping_method: shipping_method)
+            new_shipping_method.calculator = duplicate_calculator(shipping_method.calculator)
+            save_model(model_instance: new_shipping_method, context: "shipping method #{shipping_method.id}")
+          end
+
+          def find_or_initialize_shipping_method(shipping_method:)
+            @vendor.shipping_methods.find_by(name: shipping_method_name(shipping_method: shipping_method)) || Spree::ShippingMethod.new
+          end
+
+          def assign_shipping_method_attributes(new_shipping_method:, shipping_method:)
+            new_shipping_method.name = shipping_method_name(shipping_method: shipping_method)
+            new_shipping_method.display_on = shipping_method.display_on
+            new_shipping_method.tracking_url = shipping_method.tracking_url
+            new_shipping_method.admin_name = shipping_method.admin_name
+            new_shipping_method.tax_category = shipping_method.tax_category
+            new_shipping_method.code = unique_shipping_method_code(shipping_method: shipping_method, new_shipping_method: new_shipping_method)
+            new_shipping_method.public_metadata = shipping_method.public_metadata if new_shipping_method.respond_to?(:public_metadata=)
+            new_shipping_method.private_metadata = shipping_method.private_metadata if new_shipping_method.respond_to?(:private_metadata=)
+            new_shipping_method.estimated_transit_business_days_min = shipping_method.estimated_transit_business_days_min
+            new_shipping_method.estimated_transit_business_days_max = shipping_method.estimated_transit_business_days_max
+            new_shipping_method.external_id = shipping_method.external_id if new_shipping_method.respond_to?(:external_id=)
+            new_shipping_method.deleted_at = nil if new_shipping_method.respond_to?(:deleted_at=)
+          end
+
+          def shipping_method_name(shipping_method:)
+            "#{shipping_method.name} - #{@new_store.name}"
+          end
+
+          def remapped_shipping_categories(shipping_method:)
+            shipping_method.shipping_categories.filter_map do |shipping_category|
+              @shipping_categories_cache[shipping_category.id]&.first ||
+                @shipping_categories_cache[shipping_category.name]&.first ||
+                shipping_category
             end
+          end
+
+          def resolved_zones(shipping_method:)
+            shipping_method.zones.filter_map { |zone| @zone_resolver.resolve(zone) }
+          end
+
+          def unique_shipping_method_code(shipping_method:, new_shipping_method:)
+            base_code = shipping_method.code.presence || shipping_method.name.to_s.parameterize(separator: '_')
+
+            unique_value(base_value: base_code, separator: '_', max_length: 255) do |candidate|
+              @vendor.shipping_methods.where.not(id: new_shipping_method.id).where(code: candidate).exists?
+            end
+          end
+
+          def duplicate_calculator(calculator)
+            return if calculator.blank?
+
+            new_calculator = calculator.dup
+            new_calculator.created_at = nil if new_calculator.respond_to?(:created_at=)
+            new_calculator.updated_at = nil if new_calculator.respond_to?(:updated_at=)
+            new_calculator.preferences = calculator.preferences.deep_dup if new_calculator.respond_to?(:preferences=) && calculator.respond_to?(:preferences)
+            new_calculator
           end
         end
       end

--- a/app/services/spree/olitt/clone_store/duplicators/stock_items_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/stock_items_duplicator.rb
@@ -1,0 +1,95 @@
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        class StockItemsDuplicator < BaseDuplicator
+          DEFAULT_STOCK_COUNT = 5
+
+          def initialize(old_store:, new_store:, vendor:, stock_locations_cache:, variants_cache:)
+            super()
+            @old_store = old_store
+            @new_store = new_store
+            @vendor = vendor
+            @stock_locations_cache = stock_locations_cache
+            @variants_cache = variants_cache
+          end
+
+          def handle_clone_stock_items
+            source_variants.each do |old_variant|
+              clone_variant_stock_items(old_variant)
+            rescue StandardError => e
+              record_errors([e.message], context: "variant #{old_variant.id}")
+            end
+          end
+
+          private
+
+          def source_variants
+            @old_store.products.includes(variants_including_master: :stock_items).flat_map(&:variants_including_master).uniq(&:id)
+          end
+
+          def clone_variant_stock_items(old_variant)
+            new_variant = @variants_cache[old_variant.id]&.first
+            return if new_variant.blank?
+
+            copied_any_stock_items = false
+            old_variant.stock_items.each do |old_stock_item|
+              new_stock_location = remapped_stock_location(old_stock_item: old_stock_item)
+              next if new_stock_location.blank?
+
+              new_stock_item = new_variant.stock_items.find_or_initialize_by(stock_location: new_stock_location)
+              new_stock_item.count_on_hand = old_stock_item.count_on_hand
+              new_stock_item.backorderable = old_stock_item.backorderable
+              new_stock_item.public_metadata = old_stock_item.public_metadata if new_stock_item.respond_to?(:public_metadata=)
+              new_stock_item.private_metadata = old_stock_item.private_metadata if new_stock_item.respond_to?(:private_metadata=)
+              new_stock_item.external_id = old_stock_item.external_id if new_stock_item.respond_to?(:external_id=)
+              new_stock_item.deleted_at = nil if new_stock_item.respond_to?(:deleted_at=)
+              copied_any_stock_items = true if save_model(model_instance: new_stock_item, context: "stock item #{old_stock_item.id}")
+            end
+
+            ensure_default_stock_item(old_variant: old_variant, new_variant: new_variant) unless copied_any_stock_items || variant_has_stock_items?(new_variant)
+          end
+
+          def remapped_stock_location(old_stock_item:)
+            @stock_locations_cache[old_stock_item.stock_location_id]&.first || default_stock_location
+          end
+
+          def ensure_default_stock_item(old_variant:, new_variant:)
+            new_stock_location = default_stock_location
+            return if new_stock_location.blank?
+
+            new_stock_item = new_variant.stock_items.find_or_initialize_by(stock_location: new_stock_location)
+            new_stock_item.count_on_hand = fallback_count_on_hand(old_variant: old_variant)
+            new_stock_item.backorderable = fallback_backorderable(old_variant: old_variant)
+            new_stock_item.deleted_at = nil if new_stock_item.respond_to?(:deleted_at=)
+            save_model(model_instance: new_stock_item, context: "default stock item for variant #{old_variant.id}")
+          end
+
+          def variant_has_stock_items?(new_variant)
+            stock_items = new_variant.stock_items
+            return stock_items.exists? if stock_items.respond_to?(:exists?)
+
+            stock_items.any?
+          end
+
+          def default_stock_location
+            return @default_stock_location if defined?(@default_stock_location)
+
+            @default_stock_location = @stock_locations_cache[:default]&.first ||
+                                      @vendor.stock_locations.order(default: :desc, id: :asc).first ||
+                                      @stock_locations_cache.values.flatten.compact.first
+          end
+
+          def fallback_count_on_hand(old_variant:)
+            source_stock_item = old_variant.stock_items.first
+            source_stock_item&.count_on_hand.presence || ENV.fetch('CLONE_DEFAULT_STOCK_COUNT', DEFAULT_STOCK_COUNT).to_i
+          end
+
+          def fallback_backorderable(old_variant:)
+            old_variant.stock_items.any?(&:backorderable)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/spree/olitt/clone_store/duplicators/stock_locations_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/stock_locations_duplicator.rb
@@ -1,0 +1,160 @@
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        class StockLocationsDuplicator < BaseDuplicator
+          DEFAULT_STOCK_LOCATION_NAME = 'US location'.freeze
+
+          attr_reader :cloned_locations, :locations_cache
+
+          def initialize(old_store:, new_store:, vendor:)
+            super()
+            @old_store = old_store
+            @new_store = new_store
+            @vendor = vendor
+            @cloned_locations = []
+            @locations_cache = {}
+          end
+
+          def handle_clone_stock_locations
+            old_locations = source_stock_locations
+            return create_fallback_stock_location if old_locations.empty?
+
+            reusable_location = reusable_default_stock_location(old_locations: old_locations)
+
+            old_locations.each_with_index do |old_location, index|
+              clone_stock_location(old_location: old_location, target_location: index.zero? ? reusable_location : nil)
+            rescue StandardError => e
+              record_errors([e.message], context: "stock location #{old_location.id}")
+            end
+          end
+
+          private
+
+          def source_stock_locations
+            locations = source_vendor_stock_locations + source_variant_stock_locations
+            locations.compact.uniq(&:id).sort_by { | location| [location.default ? 0 : 1, location.id || 0] }
+          end
+
+          def source_vendor_stock_locations
+            return [] unless source_vendor.present? && source_vendor.respond_to?(:stock_locations)
+
+            source_vendor.stock_locations.includes(:country, :state).order(default: :desc, id: :asc).to_a
+          end
+
+          def source_variant_stock_locations
+            @old_store.products
+                      .includes(variants_including_master: { stock_items: :stock_location })
+                      .flat_map(&:variants_including_master)
+                      .flat_map(&:stock_items)
+                      .map(&:stock_location)
+                      .compact
+                      .uniq(&:id)
+          end
+
+          def source_vendor
+            return @source_vendor if defined?(@source_vendor)
+
+            @source_vendor = @old_store.respond_to?(:vendor) ? @old_store.vendor : nil
+          end
+
+          def clone_stock_location(old_location:, target_location: nil)
+            new_location = target_location || find_existing_stock_location(old_location: old_location) || Spree::StockLocation.new
+
+            assign_vendor(model_instance: new_location, vendor: @vendor)
+            assign_stock_location_attributes(new_location: new_location, old_location: old_location)
+            new_location.name = unique_stock_location_name(old_location: old_location, new_location: new_location)
+            saved = save_model(model_instance: new_location, context: "stock location #{old_location.id}")
+            return unless saved
+
+            @cloned_locations << new_location unless @cloned_locations.include?(new_location)
+            @locations_cache[old_location.id] = [new_location]
+            @locations_cache[old_location.name] = [new_location]
+            @locations_cache[:default] = [new_location] if new_location.default
+          end
+
+          def create_fallback_stock_location
+            new_location = reusable_default_stock_location(old_locations: []) ||
+                           @vendor.stock_locations.find_by(default: true) ||
+                           Spree::StockLocation.new
+
+            assign_vendor(model_instance: new_location, vendor: @vendor)
+            assign_fallback_stock_location_attributes(new_location: new_location)
+            new_location.name = unique_fallback_stock_location_name(new_location: new_location)
+            saved = save_model(model_instance: new_location, context: 'fallback stock location')
+            return unless saved
+
+            @cloned_locations << new_location unless @cloned_locations.include?(new_location)
+            @locations_cache[:default] = [new_location]
+            @locations_cache[new_location.name] = [new_location]
+          end
+
+          def assign_stock_location_attributes(new_location:, old_location:)
+            new_location.admin_name = old_location.admin_name
+            new_location.address1 = old_location.address1
+            new_location.address2 = old_location.address2
+            new_location.city = old_location.city
+            new_location.state = old_location.state
+            new_location.state_name = old_location.state_name
+            new_location.country = old_location.country || @new_store.default_country
+            new_location.zipcode = old_location.zipcode
+            new_location.phone = old_location.phone
+            new_location.active = old_location.active
+            new_location.backorderable_default = old_location.backorderable_default
+            new_location.propagate_all_variants = old_location.propagate_all_variants
+            new_location.company = old_location.company
+            new_location.default = old_location.default
+            new_location.deleted_at = nil if new_location.respond_to?(:deleted_at=)
+          end
+
+          def assign_fallback_stock_location_attributes(new_location:)
+            new_location.admin_name = @new_store.name
+            new_location.country = fallback_country
+            new_location.active = true
+            new_location.backorderable_default = false
+            new_location.propagate_all_variants = false
+            new_location.company = @new_store.name
+            new_location.default = true
+            new_location.deleted_at = nil if new_location.respond_to?(:deleted_at=)
+          end
+
+          def find_existing_stock_location(old_location:)
+            @vendor.stock_locations.find_by(name: old_location.name)
+          end
+
+          def unique_stock_location_name(old_location:, new_location:)
+            base_name = old_location.name.presence || @new_store.name
+
+            unique_value(base_value: base_name) do |candidate|
+              @vendor.stock_locations.where.not(id: new_location.id).where(name: candidate).exists?
+            end
+          end
+
+          def unique_fallback_stock_location_name(new_location:)
+            unique_value(base_value: DEFAULT_STOCK_LOCATION_NAME) do |candidate|
+              @vendor.stock_locations.where.not(id: new_location.id).where(name: candidate).exists?
+            end
+          end
+
+          def fallback_country
+            @new_store.default_country || Spree::Country.find_by(iso: 'US') || Spree::Country.first
+          end
+
+          def reusable_default_stock_location(old_locations:)
+            return if old_locations.empty?
+
+            current_locations = @vendor.stock_locations.order(default: :desc, id: :asc).to_a
+            return if current_locations.size != 1
+
+            stock_location = current_locations.first
+            return unless stock_location.name == @vendor.name
+            return if stock_location.stock_items.exists?
+            return if old_locations.any? { |old_location| old_location.name == stock_location.name }
+
+            stock_location
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/spree/olitt/clone_store/duplicators/vendor_addresses_duplicator.rb
+++ b/app/services/spree/olitt/clone_store/duplicators/vendor_addresses_duplicator.rb
@@ -1,0 +1,83 @@
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        class VendorAddressesDuplicator < BaseDuplicator
+          ADDRESS_ATTRIBUTES = %w[
+            firstname lastname company address1 address2 city zipcode phone state_name
+            alternative_phone state_id country_id public_metadata private_metadata
+          ].freeze
+
+          def initialize(old_store:, new_store:, vendor:, stock_locations_duplicator: nil)
+            super()
+            @old_store = old_store
+            @new_store = new_store
+            @vendor = vendor
+            @stock_locations_duplicator = stock_locations_duplicator
+          end
+
+          def handle_clone_vendor_addresses
+            source_vendor = source_vendor_record
+            clone_billing_address(source_vendor: source_vendor)
+            clone_returns_address(source_vendor: source_vendor)
+          end
+
+          private
+
+          def source_vendor_record
+            return @source_vendor_record if defined?(@source_vendor_record)
+
+            @source_vendor_record = @old_store.respond_to?(:vendor) ? @old_store.vendor : nil
+          end
+
+          def clone_billing_address(source_vendor:)
+            source_address = source_vendor&.billing_address || fallback_address_from_stock_location
+            clone_address(
+              source_address: source_address,
+              target_address: @vendor.billing_address,
+              target_class: Spree::BillingAddress,
+              writer: :billing_address=
+            )
+          end
+
+          def clone_returns_address(source_vendor:)
+            source_address = source_vendor&.returns_address || source_vendor&.billing_address || fallback_address_from_stock_location
+            clone_address(
+              source_address: source_address,
+              target_address: @vendor.returns_address,
+              target_class: Spree::ReturnsAddress,
+              writer: :returns_address=
+            )
+          end
+
+          def clone_address(source_address:, target_address:, target_class:, writer:)
+            return if source_address.blank?
+
+            address = target_address || target_class.new
+            assign_address_attributes(address: address, source_address: source_address)
+            @vendor.public_send(writer, address)
+
+            save_model(model_instance: @vendor, context: target_class.name.demodulize.underscore.humanize.downcase)
+          rescue StandardError => e
+            record_errors([e.message], context: target_class.name.demodulize.underscore.humanize.downcase)
+          end
+
+          def assign_address_attributes(address:, source_address:)
+            address.assign_attributes(source_address.attributes.slice(*ADDRESS_ATTRIBUTES))
+            address.user = nil if address.respond_to?(:user=)
+            address.deleted_at = nil if address.respond_to?(:deleted_at=)
+          end
+
+          def fallback_address_from_stock_location
+            stock_location = Array(@stock_locations_duplicator&.cloned_locations).find(&:default) ||
+                             Array(@stock_locations_duplicator&.cloned_locations).first ||
+                             @vendor.stock_locations.order(default: :desc, id: :asc).first
+            return if stock_location.blank?
+
+            stock_location.address
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/spree/olitt/clone_store/store_clone_runner.rb
+++ b/app/services/spree/olitt/clone_store/store_clone_runner.rb
@@ -1,13 +1,19 @@
 require_relative 'duplicators/linked_resource_duplicator'
 require_relative 'duplicators/menu_items_duplicator'
 require_relative 'duplicators/menus_duplicator'
+require_relative 'duplicators/option_types_duplicator'
 require_relative 'duplicators/pages_duplicator'
 require_relative 'duplicators/payment_methods_duplicator'
 require_relative 'duplicators/products_duplicator'
 require_relative 'duplicators/sections_duplicator'
+require_relative 'duplicators/shipping_categories_duplicator'
 require_relative 'duplicators/shipping_methods_duplicator'
+require_relative 'duplicators/stock_items_duplicator'
+require_relative 'duplicators/stock_locations_duplicator'
 require_relative 'duplicators/taxonomies_duplicator'
 require_relative 'duplicators/taxons_duplicator'
+require_relative 'duplicators/vendor_addresses_duplicator'
+require_relative 'zone_resolver'
 
 module Spree
   module Olitt
@@ -26,6 +32,21 @@ module Spree
 
         def call
           linked_resource = Duplicators::LinkedResourceDuplicator.new(old_store: @old_store, new_store: @new_store)
+
+          stock_locations_duplicator = Duplicators::StockLocationsDuplicator.new(
+            old_store: @old_store,
+            new_store: @new_store,
+            vendor: @vendor
+          )
+          run_section('stock locations', stock_locations_duplicator) { stock_locations_duplicator.handle_clone_stock_locations }
+
+          vendor_addresses_duplicator = Duplicators::VendorAddressesDuplicator.new(
+            old_store: @old_store,
+            new_store: @new_store,
+            vendor: @vendor,
+            stock_locations_duplicator: stock_locations_duplicator
+          )
+          run_section('vendor addresses', vendor_addresses_duplicator) { vendor_addresses_duplicator.handle_clone_vendor_addresses }
 
           taxonomies_duplicator = Duplicators::TaxonomiesDuplicator.new(
             old_store: @old_store,
@@ -52,14 +73,44 @@ module Spree
           run_section('pages', page_duplicator) { page_duplicator.handle_clone_pages }
           linked_resource.pages_cache = page_duplicator.pages_cache
 
+          shipping_categories_duplicator = Duplicators::ShippingCategoriesDuplicator.new(
+            old_store: @old_store,
+            new_store: @new_store,
+            vendor: @vendor
+          )
+          run_section('shipping categories', shipping_categories_duplicator) do
+            shipping_categories_duplicator.handle_clone_shipping_categories
+          end
+
+          option_types_duplicator = Duplicators::OptionTypesDuplicator.new(
+            old_store: @old_store,
+            new_store: @new_store,
+            vendor: @vendor
+          )
+          run_section('option types', option_types_duplicator) do
+            option_types_duplicator.handle_clone_option_types
+          end
+
           product_duplicator = Duplicators::ProductsDuplicator.new(
             old_store: @old_store,
             new_store: @new_store,
             vendor: @vendor,
-            taxon_cache: taxon_duplicator.taxons_cache
+            taxon_cache: taxon_duplicator.taxons_cache,
+            shipping_category_cache: shipping_categories_duplicator.shipping_categories_cache,
+            option_type_cache: option_types_duplicator.option_types_cache,
+            option_value_cache: option_types_duplicator.option_values_cache
           )
           run_section('products', product_duplicator) { product_duplicator.handle_clone_products }
           linked_resource.products_cache = product_duplicator.products_cache
+
+          stock_items_duplicator = Duplicators::StockItemsDuplicator.new(
+            old_store: @old_store,
+            new_store: @new_store,
+            vendor: @vendor,
+            stock_locations_cache: stock_locations_duplicator.locations_cache,
+            variants_cache: product_duplicator.variants_cache
+          )
+          run_section('stock items', stock_items_duplicator) { stock_items_duplicator.handle_clone_stock_items }
 
           section_duplicator = Duplicators::SectionsDuplicator.new(
             old_store: @old_store,
@@ -88,10 +139,16 @@ module Spree
           run_section('menu items', menu_items_duplicator) { menu_items_duplicator.handle_clone_menu_items }
 
           run_section('payment methods') do
-            Duplicators::PaymentMethodsDuplicator.new(new_store: @new_store, vendor: @vendor).duplicate
+            Duplicators::PaymentMethodsDuplicator.new(old_store: @old_store, new_store: @new_store, vendor: @vendor).duplicate
           end
           run_section('shipping methods') do
-            Duplicators::ShippingMethodsDuplicator.new(vendor: @vendor, new_store: @new_store).duplicate
+            Duplicators::ShippingMethodsDuplicator.new(
+              old_store: @old_store,
+              vendor: @vendor,
+              new_store: @new_store,
+              shipping_categories_cache: shipping_categories_duplicator.shipping_categories_cache,
+              zone_resolver: ZoneResolver.new
+            ).duplicate
           end
           run_section('store images') { attach_store_images }
 

--- a/app/services/spree/olitt/clone_store/zone_resolver.rb
+++ b/app/services/spree/olitt/clone_store/zone_resolver.rb
@@ -1,0 +1,34 @@
+module Spree
+  module Olitt
+    module CloneStore
+      class ZoneResolver
+        def resolve(source_zone)
+          return if source_zone.blank?
+
+          Spree::Zone.find_by(id: source_zone.id) || find_equivalent_zone(source_zone)
+        end
+
+        private
+
+        def find_equivalent_zone(source_zone)
+          candidate = Spree::Zone.includes(:zone_members).find_by(name: source_zone.name, kind: source_zone.kind)
+          return candidate if candidate.present? && same_members?(candidate, source_zone)
+
+          Spree::Zone.includes(:zone_members).detect { |zone| same_identity?(zone, source_zone) && same_members?(zone, source_zone) }
+        end
+
+        def same_identity?(candidate, source_zone)
+          candidate.kind == source_zone.kind && candidate.name == source_zone.name
+        end
+
+        def same_members?(candidate, source_zone)
+          zone_members(candidate) == zone_members(source_zone)
+        end
+
+        def zone_members(zone)
+          zone.zone_members.map { |member| [member.zoneable_type, member.zoneable_id] }.sort
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/spree/olitt/clone_store/product_helpers_spec.rb
+++ b/spec/helpers/spree/olitt/clone_store/product_helpers_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      describe ProductHelpers do
+        subject(:helper_host) do
+          Class.new do
+            include Spree::Olitt::CloneStore::ProductHelpers
+          end.new
+        end
+
+        describe '#duplicate_variant' do
+          it 'copies variant images and prices alongside option values' do
+            option_values = [instance_double('Spree::OptionValue')]
+            source_image = instance_double('Spree::Image')
+            cloned_image = instance_double('Spree::Image')
+            source_price = instance_double('Spree::Price')
+            cloned_price = instance_double('Spree::Price')
+            variant = instance_double(
+              'Spree::Variant',
+              sku: 'SKU-1',
+              option_values: option_values,
+              images: [source_image],
+              prices: [source_price]
+            )
+            new_variant = instance_double('Spree::Variant')
+
+            allow(variant).to receive(:dup).and_return(new_variant)
+            allow(helper_host).to receive(:duplicate_image).with(image: source_image).and_return(cloned_image)
+            allow(source_price).to receive(:dup).and_return(cloned_price)
+
+            allow(new_variant).to receive(:sku=)
+            allow(new_variant).to receive(:deleted_at=)
+            allow(new_variant).to receive(:vendor_id=)
+            allow(new_variant).to receive(:tax_category=)
+            allow(new_variant).to receive(:option_values=)
+            allow(new_variant).to receive(:images=)
+            allow(new_variant).to receive(:prices=)
+            allow(cloned_price).to receive(:deleted_at=)
+            allow(cloned_price).to receive(:created_at=)
+            allow(cloned_price).to receive(:updated_at=)
+
+            duplicated_variant = helper_host.duplicate_variant(
+              variant: variant,
+              vendor_id: 12,
+              code: 'new-store',
+              option_values: option_values,
+              tax_category: nil
+            )
+
+            expect(duplicated_variant).to eq(new_variant)
+            expect(new_variant).to have_received(:images=).with([cloned_image])
+            expect(new_variant).to have_received(:prices=).with([cloned_price])
+            expect(new_variant).to have_received(:option_values=).with(option_values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/option_types_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/option_types_duplicator_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe OptionTypesDuplicator do
+          describe '#handle_clone_option_types' do
+            it 'clones option types and values into vendor-scoped copies' do
+              option_value = instance_double(
+                'Spree::OptionValue',
+                id: 9,
+                name: 'large',
+                presentation: 'Large',
+                position: 1,
+                public_metadata: {},
+                private_metadata: {}
+              )
+              option_type = instance_double(
+                'Spree::OptionType',
+                id: 4,
+                vendor_id: 2,
+                name: 'size',
+                presentation: 'Size',
+                position: 1,
+                filterable: true,
+                public_metadata: {},
+                private_metadata: {},
+                option_values: [option_value]
+              )
+              product = instance_double('Spree::Product', option_types: [option_type])
+              products_relation = instance_double('ActiveRecord::Relation')
+              old_store = instance_double('Spree::Store', products: products_relation)
+              new_store = instance_double('Spree::Store', code: 'new-store')
+              vendor = instance_double('Spree::Vendor', id: 12)
+              new_option_type = instance_double('Spree::OptionType')
+              new_option_values_relation = instance_double('ActiveRecord::Relation')
+              new_option_value = instance_double('Spree::OptionValue')
+
+              allow(products_relation).to receive(:includes).with(option_types: :option_values).and_return([product])
+              allow(Spree::OptionType).to receive(:new).and_return(new_option_type)
+              allow(Spree::OptionValue).to receive(:new).and_return(new_option_value)
+              allow(new_option_type).to receive(:vendor_id=)
+              allow(new_option_type).to receive(:name=)
+              allow(new_option_type).to receive(:presentation=)
+              allow(new_option_type).to receive(:position=)
+              allow(new_option_type).to receive(:filterable=)
+              allow(new_option_type).to receive(:public_metadata=)
+              allow(new_option_type).to receive(:private_metadata=)
+              allow(new_option_type).to receive(:id).and_return(nil)
+              allow(new_option_type).to receive(:save).and_return(true)
+              allow(new_option_type).to receive(:option_values).and_return(new_option_values_relation)
+              allow(new_option_values_relation).to receive(:find_by).with(name: 'large').and_return(nil)
+
+              allow(new_option_value).to receive(:vendor_id=)
+              allow(new_option_value).to receive(:option_type=)
+              allow(new_option_value).to receive(:name=)
+              allow(new_option_value).to receive(:presentation=)
+              allow(new_option_value).to receive(:position=)
+              allow(new_option_value).to receive(:public_metadata=)
+              allow(new_option_value).to receive(:private_metadata=)
+              allow(new_option_value).to receive(:save).and_return(true)
+
+              duplicator = described_class.new(old_store: old_store, new_store: new_store, vendor: vendor)
+              allow(duplicator).to receive(:unique_option_type_name).and_return('size_new-store')
+
+              duplicator.handle_clone_option_types
+
+              expect(new_option_type).to have_received(:vendor_id=).with(12)
+              expect(new_option_type).to have_received(:name=).with('size_new-store')
+              expect(new_option_value).to have_received(:option_type=).with(new_option_type)
+              expect(duplicator.option_types_cache[4]).to eq([new_option_type])
+              expect(duplicator.option_values_cache[9]).to eq([new_option_value])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/payment_methods_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/payment_methods_duplicator_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe PaymentMethodsDuplicator do
+          describe '#duplicate' do
+            it 'clones payment methods from the source store without copying credentials' do
+              old_store = instance_double('Spree::Store')
+              new_store = instance_double('Spree::Store', id: 44)
+              vendor = instance_double('Spree::Vendor', id: 12)
+              source_payment_method = instance_double(
+                'Spree::PaymentMethod',
+                id: 7,
+                type: 'Spree::Gateway::PayPalGateway',
+                name: 'PayPal',
+                description: 'Primary checkout gateway',
+                active: true,
+                display_on: 'both',
+                auto_capture: true,
+                position: 1,
+                preferences: { 'login' => 'merchant@example.com' },
+                settings: { 'mode' => 'live' },
+                public_metadata: { 'provider' => 'paypal' },
+                private_metadata: { 'secret_present' => true }
+              )
+              cloned_payment_method = instance_double('Spree::PaymentMethod')
+
+              duplicator = described_class.new(old_store: old_store, new_store: new_store, vendor: vendor)
+
+              allow(duplicator).to receive(:source_payment_methods).and_return([source_payment_method])
+              allow(duplicator).to receive(:existing_payment_method).with(payment_method: source_payment_method).and_return(nil)
+              allow(source_payment_method).to receive(:dup).and_return(cloned_payment_method)
+              allow(duplicator).to receive(:assign_vendor).with(model_instance: cloned_payment_method, vendor: vendor)
+
+              allow(cloned_payment_method).to receive(:name=)
+              allow(cloned_payment_method).to receive(:description=)
+              allow(cloned_payment_method).to receive(:active=)
+              allow(cloned_payment_method).to receive(:display_on=)
+              allow(cloned_payment_method).to receive(:auto_capture=)
+              allow(cloned_payment_method).to receive(:position=)
+              allow(cloned_payment_method).to receive(:public_metadata=)
+              allow(cloned_payment_method).to receive(:stores=)
+              allow(cloned_payment_method).to receive(:created_at=)
+              allow(cloned_payment_method).to receive(:updated_at=)
+              allow(cloned_payment_method).to receive(:deleted_at=)
+              allow(duplicator).to receive(:save_model).with(model_instance: cloned_payment_method, context: 'payment method 7').and_return(true)
+
+              duplicator.duplicate
+
+              expect(source_payment_method).to have_received(:dup)
+              expect(cloned_payment_method).to have_received(:name=).with('PayPal')
+              expect(cloned_payment_method).not_to have_received(:preferences=)
+              expect(cloned_payment_method).not_to have_received(:settings=)
+              expect(cloned_payment_method).not_to have_received(:private_metadata=)
+              expect(cloned_payment_method).to have_received(:stores=).with([new_store])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/products_tax_category_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/products_tax_category_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe ProductsDuplicator do
+          describe '#resolve_tax_category' do
+            it 'reuses a matching shared tax category when the original id is unavailable' do
+              old_store = instance_double('Spree::Store', products: instance_double('ActiveRecord::Relation'))
+              new_store = instance_double('Spree::Store', code: 'new-store')
+              vendor = instance_double('Spree::Vendor', id: 99)
+              old_tax_category = instance_double('Spree::TaxCategory', id: 21, name: 'Clothing', tax_code: 'CLTH', is_default?: false)
+              new_tax_category = instance_double('Spree::TaxCategory')
+
+              duplicator = described_class.new(
+                old_store: old_store,
+                new_store: new_store,
+                vendor: vendor,
+                taxon_cache: {}
+              )
+
+              allow(Spree::TaxCategory).to receive(:find_by).with(id: 21).and_return(nil)
+              allow(Spree::TaxCategory).to receive(:find_by).with(name: 'Clothing').and_return(new_tax_category)
+
+              resolved_tax_category = duplicator.send(:resolve_tax_category, old_tax_category)
+
+              expect(resolved_tax_category).to eq(new_tax_category)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/shipping_categories_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/shipping_categories_duplicator_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe ShippingCategoriesDuplicator do
+          describe '#handle_clone_shipping_categories' do
+            it 'duplicates unique source shipping categories and caches them' do
+              shipping_category = instance_double('Spree::ShippingCategory', id: 3, name: 'Physical Goods')
+              product = instance_double('Spree::Product', shipping_category: shipping_category)
+              products_relation = instance_double('ActiveRecord::Relation')
+              source_vendor = instance_double('Spree::Vendor', shipping_methods: [])
+              old_store = instance_double('Spree::Store', products: products_relation, vendor: source_vendor)
+              vendor = instance_double('Spree::Vendor', id: 19)
+              new_shipping_category = instance_double('Spree::ShippingCategory')
+              vendor_shipping_categories = instance_double('ActiveRecord::Relation')
+
+              allow(products_relation).to receive(:includes).with(:shipping_category).and_return([product])
+              allow(Spree::ShippingCategory).to receive(:where).with(vendor_id: 19).and_return(vendor_shipping_categories)
+              allow(vendor_shipping_categories).to receive(:find_by).with(name: 'Physical Goods').and_return(nil)
+
+              allow(Spree::ShippingCategory).to receive(:new).and_return(new_shipping_category)
+              allow(new_shipping_category).to receive(:vendor_id=)
+              allow(new_shipping_category).to receive(:name=)
+              allow(new_shipping_category).to receive(:id).and_return(nil)
+              allow(new_shipping_category).to receive(:save).and_return(true)
+
+              duplicator = described_class.new(old_store: old_store, new_store: instance_double('Spree::Store'), vendor: vendor)
+              allow(duplicator).to receive(:unique_shipping_category_name).and_return('Physical Goods')
+
+              duplicator.handle_clone_shipping_categories
+
+              expect(new_shipping_category).to have_received(:vendor_id=).with(19)
+              expect(new_shipping_category).to have_received(:name=).with('Physical Goods')
+              expect(duplicator.shipping_categories_cache[3]).to eq([new_shipping_category])
+              expect(duplicator.shipping_categories_cache['Physical Goods']).to eq([new_shipping_category])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/stock_items_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/stock_items_duplicator_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe StockItemsDuplicator do
+          describe '#handle_clone_stock_items' do
+            it 'copies stock counts to the cloned variant and stock location' do
+              old_stock_item = instance_double(
+                'Spree::StockItem',
+                id: 21,
+                stock_location_id: 7,
+                count_on_hand: 15,
+                backorderable: true,
+                public_metadata: {},
+                private_metadata: {},
+                external_id: 'ext-1'
+              )
+              old_variant = instance_double('Spree::Variant', id: 4, stock_items: [old_stock_item])
+              product = instance_double('Spree::Product', variants_including_master: [old_variant])
+              products_relation = instance_double('ActiveRecord::Relation')
+              old_store = instance_double('Spree::Store', products: products_relation)
+              new_stock_location = instance_double('Spree::StockLocation')
+              new_stock_item = instance_double('Spree::StockItem')
+              new_stock_items_relation = instance_double('ActiveRecord::Relation')
+              new_variant = instance_double('Spree::Variant', stock_items: new_stock_items_relation)
+
+              allow(products_relation).to receive(:includes).with(variants_including_master: :stock_items).and_return([product])
+              allow(new_stock_items_relation).to receive(:find_or_initialize_by).with(stock_location: new_stock_location).and_return(new_stock_item)
+              allow(new_stock_item).to receive(:count_on_hand=)
+              allow(new_stock_item).to receive(:backorderable=)
+              allow(new_stock_item).to receive(:public_metadata=)
+              allow(new_stock_item).to receive(:private_metadata=)
+              allow(new_stock_item).to receive(:external_id=)
+              allow(new_stock_item).to receive(:deleted_at=)
+              allow(new_stock_item).to receive(:save).and_return(true)
+
+              duplicator = described_class.new(
+                old_store: old_store,
+                new_store: instance_double('Spree::Store'),
+                vendor: instance_double('Spree::Vendor', stock_locations: instance_double('ActiveRecord::Relation')),
+                stock_locations_cache: { 7 => [new_stock_location] },
+                variants_cache: { 4 => [new_variant] }
+              )
+
+              duplicator.handle_clone_stock_items
+
+              expect(new_stock_item).to have_received(:count_on_hand=).with(15)
+              expect(new_stock_item).to have_received(:backorderable=).with(true)
+              expect(new_stock_item).to have_received(:external_id=).with('ext-1')
+            end
+
+            it 'creates a default stock item when the source variant has none' do
+              old_variant = instance_double('Spree::Variant', id: 4, stock_items: [])
+              product = instance_double('Spree::Product', variants_including_master: [old_variant])
+              products_relation = instance_double('ActiveRecord::Relation')
+              old_store = instance_double('Spree::Store', products: products_relation)
+              default_stock_location = instance_double('Spree::StockLocation')
+              new_stock_item = instance_double('Spree::StockItem')
+              new_stock_items_relation = instance_double('ActiveRecord::Relation')
+              vendor_stock_locations = instance_double('ActiveRecord::Relation')
+              new_variant = instance_double('Spree::Variant', stock_items: new_stock_items_relation)
+
+              allow(products_relation).to receive(:includes).with(variants_including_master: :stock_items).and_return([product])
+              allow(new_stock_items_relation).to receive(:find_or_initialize_by).with(stock_location: default_stock_location).and_return(new_stock_item)
+              allow(new_stock_items_relation).to receive(:exists?).and_return(false)
+              allow(new_stock_item).to receive(:count_on_hand=)
+              allow(new_stock_item).to receive(:backorderable=)
+              allow(new_stock_item).to receive(:deleted_at=)
+              allow(new_stock_item).to receive(:save).and_return(true)
+              allow(vendor_stock_locations).to receive(:order).with(default: :desc, id: :asc).and_return([default_stock_location])
+
+              duplicator = described_class.new(
+                old_store: old_store,
+                new_store: instance_double('Spree::Store'),
+                vendor: instance_double('Spree::Vendor', stock_locations: vendor_stock_locations),
+                stock_locations_cache: { default: [default_stock_location] },
+                variants_cache: { 4 => [new_variant] }
+              )
+
+              duplicator.handle_clone_stock_items
+
+              expect(new_stock_item).to have_received(:count_on_hand=).with(5)
+              expect(new_stock_item).to have_received(:backorderable=).with(false)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/stock_locations_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/stock_locations_duplicator_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe StockLocationsDuplicator do
+          describe '#handle_clone_stock_locations' do
+            it 'duplicates vendor stock locations from the source vendor' do
+              old_location = instance_double(
+                'Spree::StockLocation',
+                id: 7,
+                name: 'Main Warehouse',
+                admin_name: 'HQ',
+                address1: '123 Market Street',
+                address2: 'Suite 2',
+                city: 'Nairobi',
+                state: nil,
+                state_name: 'Nairobi County',
+                country: :country,
+                zipcode: '00100',
+                phone: '+254700000000',
+                active: true,
+                backorderable_default: false,
+                propagate_all_variants: true,
+                company: 'ACME',
+                default: true
+              )
+
+              stock_locations_relation = instance_double('ActiveRecord::Relation')
+              source_vendor = instance_double('Spree::Vendor', stock_locations: stock_locations_relation)
+              old_store = instance_double('Spree::Store', vendor: source_vendor)
+              new_store = instance_double('Spree::Store', name: 'New Store', default_country: :country)
+              vendor_stock_locations = instance_double('ActiveRecord::Relation')
+              vendor = instance_double('Spree::Vendor', id: 9, name: 'vendor@example.com', stock_locations: vendor_stock_locations)
+              new_location = instance_double('Spree::StockLocation')
+
+              allow(stock_locations_relation).to receive(:includes).with(:country, :state).and_return(stock_locations_relation)
+              allow(stock_locations_relation).to receive(:order).with(default: :desc, id: :asc).and_return([old_location])
+              allow(vendor_stock_locations).to receive(:order).with(default: :desc, id: :asc).and_return([])
+              allow(vendor_stock_locations).to receive(:find_by).with(name: 'Main Warehouse').and_return(nil)
+              allow(vendor_stock_locations).to receive(:where).and_return(vendor_stock_locations)
+              allow(vendor_stock_locations).to receive(:exists?).and_return(false)
+
+              allow(Spree::StockLocation).to receive(:new).and_return(new_location)
+              allow(new_location).to receive(:name=)
+              allow(new_location).to receive(:admin_name=)
+              allow(new_location).to receive(:address1=)
+              allow(new_location).to receive(:address2=)
+              allow(new_location).to receive(:city=)
+              allow(new_location).to receive(:state=)
+              allow(new_location).to receive(:state_name=)
+              allow(new_location).to receive(:country=)
+              allow(new_location).to receive(:zipcode=)
+              allow(new_location).to receive(:phone=)
+              allow(new_location).to receive(:active=)
+              allow(new_location).to receive(:backorderable_default=)
+              allow(new_location).to receive(:propagate_all_variants=)
+              allow(new_location).to receive(:company=)
+              allow(new_location).to receive(:default=)
+              allow(new_location).to receive(:deleted_at=)
+              allow(new_location).to receive(:vendor_id=)
+              allow(new_location).to receive(:id).and_return(nil)
+              allow(new_location).to receive(:save).and_return(true)
+
+              duplicator = described_class.new(old_store: old_store, new_store: new_store, vendor: vendor)
+
+              duplicator.handle_clone_stock_locations
+
+              expect(new_location).to have_received(:vendor_id=).with(9)
+              expect(new_location).to have_received(:name=).with('Main Warehouse')
+              expect(new_location).to have_received(:country=).with(:country)
+              expect(duplicator.cloned_locations).to include(new_location)
+            end
+
+            it 'creates a fallback default stock location when the source store has none' do
+              products_relation = instance_double('ActiveRecord::Relation')
+              variants_relation = instance_double('ActiveRecord::Relation')
+              old_store = instance_double('Spree::Store', vendor: nil, products: products_relation)
+              new_store = instance_double('Spree::Store', name: 'Gallery shop', default_country: :us_country)
+              vendor_stock_locations = instance_double('ActiveRecord::Relation')
+              vendor = instance_double('Spree::Vendor', id: 9, name: 'vendor@example.com', stock_locations: vendor_stock_locations)
+              new_location = instance_double('Spree::StockLocation')
+
+              allow(products_relation).to receive(:includes).with(variants_including_master: { stock_items: :stock_location }).and_return([])
+              allow(vendor_stock_locations).to receive(:order).with(default: :desc, id: :asc).and_return([])
+              allow(vendor_stock_locations).to receive(:find_by).with(default: true).and_return(nil)
+              allow(vendor_stock_locations).to receive(:where).and_return(vendor_stock_locations)
+              allow(vendor_stock_locations).to receive(:exists?).and_return(false)
+
+              allow(Spree::StockLocation).to receive(:new).and_return(new_location)
+              allow(new_location).to receive(:name=)
+              allow(new_location).to receive(:admin_name=)
+              allow(new_location).to receive(:country=)
+              allow(new_location).to receive(:active=)
+              allow(new_location).to receive(:backorderable_default=)
+              allow(new_location).to receive(:propagate_all_variants=)
+              allow(new_location).to receive(:company=)
+              allow(new_location).to receive(:default=)
+              allow(new_location).to receive(:deleted_at=)
+              allow(new_location).to receive(:vendor_id=)
+              allow(new_location).to receive(:id).and_return(nil)
+              allow(new_location).to receive(:save).and_return(true)
+
+              duplicator = described_class.new(old_store: old_store, new_store: new_store, vendor: vendor)
+
+              duplicator.handle_clone_stock_locations
+
+              expect(new_location).to have_received(:name=).with('US location')
+              expect(new_location).to have_received(:country=).with(:us_country)
+              expect(new_location).to have_received(:default=).with(true)
+              expect(duplicator.locations_cache[:default]).to eq([new_location])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/duplicators/stock_locations_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/stock_locations_duplicator_spec.rb
@@ -75,7 +75,6 @@ module Spree
 
             it 'creates a fallback default stock location when the source store has none' do
               products_relation = instance_double('ActiveRecord::Relation')
-              variants_relation = instance_double('ActiveRecord::Relation')
               old_store = instance_double('Spree::Store', vendor: nil, products: products_relation)
               new_store = instance_double('Spree::Store', name: 'Gallery shop', default_country: :us_country)
               vendor_stock_locations = instance_double('ActiveRecord::Relation')

--- a/spec/services/spree/olitt/clone_store/duplicators/vendor_addresses_duplicator_spec.rb
+++ b/spec/services/spree/olitt/clone_store/duplicators/vendor_addresses_duplicator_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      module Duplicators
+        describe VendorAddressesDuplicator do
+          describe '#handle_clone_vendor_addresses' do
+            it 'copies billing and returns addresses from the source vendor' do
+              billing_address = instance_double('Spree::BillingAddress', attributes: {
+                'firstname' => 'Jane',
+                'lastname' => 'Doe',
+                'company' => 'ACME',
+                'address1' => '123 Market Street',
+                'address2' => 'Suite 2',
+                'city' => 'Nairobi',
+                'zipcode' => '00100',
+                'phone' => '+254700000000',
+                'state_name' => 'Nairobi County',
+                'alternative_phone' => nil,
+                'state_id' => nil,
+                'country_id' => 1,
+                'public_metadata' => {},
+                'private_metadata' => {}
+              })
+              returns_address = instance_double('Spree::ReturnsAddress', attributes: {
+                'firstname' => 'Warehouse',
+                'lastname' => 'Team',
+                'company' => 'ACME',
+                'address1' => 'Returns Street',
+                'address2' => nil,
+                'city' => 'Nairobi',
+                'zipcode' => '00200',
+                'phone' => '+254711111111',
+                'state_name' => 'Nairobi County',
+                'alternative_phone' => nil,
+                'state_id' => nil,
+                'country_id' => 1,
+                'public_metadata' => {},
+                'private_metadata' => {}
+              })
+
+              source_vendor = instance_double(
+                'Spree::Vendor',
+                billing_address: billing_address,
+                returns_address: returns_address
+              )
+              old_store = instance_double('Spree::Store', vendor: source_vendor)
+              vendor = instance_double('Spree::Vendor', billing_address: nil, returns_address: nil)
+              new_billing_address = instance_double('Spree::BillingAddress')
+              new_returns_address = instance_double('Spree::ReturnsAddress')
+
+              allow(Spree::BillingAddress).to receive(:new).and_return(new_billing_address)
+              allow(Spree::ReturnsAddress).to receive(:new).and_return(new_returns_address)
+
+              [new_billing_address, new_returns_address].each do |address|
+                allow(address).to receive(:assign_attributes)
+                allow(address).to receive(:user=)
+                allow(address).to receive(:deleted_at=)
+              end
+
+              allow(vendor).to receive(:billing_address=)
+              allow(vendor).to receive(:returns_address=)
+              allow(vendor).to receive(:save).and_return(true)
+
+              duplicator = described_class.new(
+                old_store: old_store,
+                new_store: instance_double('Spree::Store'),
+                vendor: vendor
+              )
+
+              duplicator.handle_clone_vendor_addresses
+
+              expect(new_billing_address).to have_received(:assign_attributes).with(hash_including('firstname' => 'Jane'))
+              expect(new_returns_address).to have_received(:assign_attributes).with(hash_including('address1' => 'Returns Street'))
+              expect(vendor).to have_received(:billing_address=).with(new_billing_address)
+              expect(vendor).to have_received(:returns_address=).with(new_returns_address)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/spree/olitt/clone_store/zone_resolver_spec.rb
+++ b/spec/services/spree/olitt/clone_store/zone_resolver_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      describe ZoneResolver do
+        describe '#resolve' do
+          it 'returns the source zone when the zone still exists by id' do
+            source_zone = instance_double('Spree::Zone', id: 5)
+
+            allow(Spree::Zone).to receive(:find_by).with(id: 5).and_return(:resolved_zone)
+
+            expect(described_class.new.resolve(source_zone)).to eq(:resolved_zone)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added StockLocationsDuplicator to clone stock locations from the old store to the new store, including handling of default and fallback locations.
- Introduced VendorAddressesDuplicator to clone billing and returns addresses for vendors, utilizing stock locations for fallback addresses.
- Enhanced StoreCloneRunner to integrate the new duplicators for stock locations and vendor addresses during the store cloning process.
- Created ZoneResolver to resolve zones based on existing records or find equivalent zones.
- Added tests for StockLocationsDuplicator, VendorAddressesDuplicator, and ZoneResolver to ensure functionality and correctness.
- Updated existing duplicators to accommodate new dependencies and ensure smooth cloning of related resources.