### PR TITLE
Feat/ensure store api key

### DIFF
--- a/app/controllers/spree/api/v2/platform/clone_stores_controller.rb
+++ b/app/controllers/spree/api/v2/platform/clone_stores_controller.rb
@@ -35,7 +35,10 @@ module Spree
           private
 
           def resolve_ensure_api_key_store
-            Spree.current_store_finder.new(url: params[:url].presence).execute
+            url = params[:url].to_s.strip
+            return nil if url.blank?
+
+            Spree.current_store_finder.new(url: url).execute
           end
 
           def render_ensure_api_key_store_not_found
@@ -47,7 +50,7 @@ module Spree
 
           def ensure_api_key_payload(store, api_key)
             {
-              data: { id: store.id, type: 'store' },
+              data: { id: store.id.to_s, type: 'store' },
               status: 'completed',
               meta: {
                 status: 'completed',

--- a/app/controllers/spree/api/v2/platform/clone_stores_controller.rb
+++ b/app/controllers/spree/api/v2/platform/clone_stores_controller.rb
@@ -24,7 +24,49 @@ module Spree
             render_clone_request_status(params[:clone_request_id])
           end
 
+          def ensure_api_key
+            store = resolve_ensure_api_key_store
+            return render_ensure_api_key_store_not_found if store.nil?
+
+            api_key = Spree::Olitt::CloneStore::StoreApiKeyProvisioner.call(store)
+            render json: ensure_api_key_payload(store, api_key), status: :ok
+          end
+
           private
+
+          def resolve_ensure_api_key_store
+            Spree.current_store_finder.new(url: params[:url].presence).execute
+          end
+
+          def render_ensure_api_key_store_not_found
+            render json: {
+              errors: ['Store not found for the provided url'],
+              meta: { status: 'not_found' }
+            }, status: :not_found
+          end
+
+          def ensure_api_key_payload(store, api_key)
+            {
+              data: { id: store.id, type: 'store' },
+              status: 'completed',
+              meta: {
+                status: 'completed',
+                public_api_key: serialize_public_api_key(api_key)
+              }
+            }
+          end
+
+          def serialize_public_api_key(api_key)
+            return nil if api_key.nil?
+
+            {
+              id: api_key.id,
+              name: api_key.name,
+              key_type: api_key.key_type,
+              token: api_key.token,
+              store_id: api_key.store_id
+            }
+          end
 
           def authorize_clone_store_request!
             if api_key_header_present?

--- a/app/services/spree/olitt/clone_store/store_api_key_provisioner.rb
+++ b/app/services/spree/olitt/clone_store/store_api_key_provisioner.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Olitt
+    module CloneStore
+      class StoreApiKeyProvisioner
+        def self.call(store)
+          new(store).call
+        end
+
+        def initialize(store)
+          @store = store
+        end
+
+        def call
+          return nil unless @store.respond_to?(:api_keys)
+
+          @store.api_keys.active.publishable.first ||
+            @store.api_keys.create!(name: 'Storefront key', key_type: 'publishable')
+        rescue ActiveRecord::RecordNotUnique
+          @store.api_keys.active.publishable.first
+        end
+      end
+    end
+  end
+end

--- a/app/services/spree/olitt/clone_store/store_api_key_provisioner.rb
+++ b/app/services/spree/olitt/clone_store/store_api_key_provisioner.rb
@@ -13,10 +13,10 @@ module Spree
         def call
           return nil unless @store.respond_to?(:api_keys)
 
-          @store.api_keys.active.publishable.first ||
+          @store.api_keys.active.publishable.order(created_at: :desc).first ||
             @store.api_keys.create!(name: 'Storefront key', key_type: 'publishable')
         rescue ActiveRecord::RecordNotUnique
-          @store.api_keys.active.publishable.first
+          @store.api_keys.active.publishable.order(created_at: :desc).first
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Spree::Core::Engine.add_routes do
     namespace :v2 do
       namespace :platform do
         post '/clone-store', to: 'clone_stores#create'
+        post '/clone-store/ensure-api-key', to: 'clone_stores#ensure_api_key'
         get '/clone-store/:clone_request_id', to: 'clone_stores#show'
       end
     end

--- a/spec/controllers/spree/api/v2/platform/clone_stores_controller_spec.rb
+++ b/spec/controllers/spree/api/v2/platform/clone_stores_controller_spec.rb
@@ -113,7 +113,7 @@ describe Spree::Api::V2::Platform::CloneStoresController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       payload = JSON.parse(response.body)
-      expect(payload.dig('data', 'id')).to eq(live_store.id)
+      expect(payload.dig('data', 'id')).to eq(live_store.id.to_s)
       expect(payload.dig('meta', 'status')).to eq('completed')
       expect(payload.dig('meta', 'public_api_key', 'token')).to be_present
       expect(payload.dig('meta', 'public_api_key', 'store_id')).to eq(live_store.id)
@@ -157,7 +157,7 @@ describe Spree::Api::V2::Platform::CloneStoresController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       payload = JSON.parse(response.body)
-      expect(payload.dig('data', 'id')).to eq(older_store.id)
+      expect(payload.dig('data', 'id')).to eq(older_store.id.to_s)
       expect(payload.dig('meta', 'public_api_key', 'store_id')).to eq(older_store.id)
       expect(older_store.reload.api_keys.active.publishable.count).to eq(1)
       expect(newer_store.reload.api_keys.active.publishable.count).to eq(0)

--- a/spec/controllers/spree/api/v2/platform/clone_stores_controller_spec.rb
+++ b/spec/controllers/spree/api/v2/platform/clone_stores_controller_spec.rb
@@ -142,4 +142,25 @@ describe Spree::Api::V2::Platform::CloneStoresController, type: :controller do
       expect(JSON.parse(response.body).dig('meta', 'status')).to eq('not_found')
     end
   end
+
+  describe '#ensure_api_key duplicate store resolution' do
+    let!(:older_store) do
+      create(:store, default: false, name: 'Older Store', url: 'conflict.example.com', code: 'older-store')
+    end
+
+    let!(:newer_store) do
+      create(:store, default: false, name: 'Newer Store', url: 'conflict.example.com', code: 'newer-store')
+    end
+
+    it 'mints the key on the oldest store when two stores share the same url' do
+      post :ensure_api_key, params: { url: 'conflict.example.com' }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      payload = JSON.parse(response.body)
+      expect(payload.dig('data', 'id')).to eq(older_store.id)
+      expect(payload.dig('meta', 'public_api_key', 'store_id')).to eq(older_store.id)
+      expect(older_store.reload.api_keys.active.publishable.count).to eq(1)
+      expect(newer_store.reload.api_keys.active.publishable.count).to eq(0)
+    end
+  end
 end

--- a/spec/controllers/spree/api/v2/platform/clone_stores_controller_spec.rb
+++ b/spec/controllers/spree/api/v2/platform/clone_stores_controller_spec.rb
@@ -94,4 +94,52 @@ describe Spree::Api::V2::Platform::CloneStoresController, type: :controller do
       expect(JSON.parse(response.body)).to eq('error' => 'Valid secret API key required')
     end
   end
+
+  describe '#ensure_api_key' do
+    let!(:live_store) do
+      create(:store, default: false, name: 'Live Store', url: 'live.example.com', code: 'live-store')
+    end
+
+    before do
+      allow(Spree.current_store_finder).to receive(:new).and_return(
+        instance_double(Spree.current_store_finder, execute: live_store)
+      )
+    end
+
+    it 'mints a publishable key for the resolved store and returns it' do
+      expect(live_store.api_keys.active.publishable.count).to eq(0)
+
+      post :ensure_api_key, params: { url: 'live.example.com' }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      payload = JSON.parse(response.body)
+      expect(payload.dig('data', 'id')).to eq(live_store.id)
+      expect(payload.dig('meta', 'status')).to eq('completed')
+      expect(payload.dig('meta', 'public_api_key', 'token')).to be_present
+      expect(payload.dig('meta', 'public_api_key', 'store_id')).to eq(live_store.id)
+      expect(live_store.api_keys.active.publishable.count).to eq(1)
+    end
+
+    it 'is idempotent and returns the same key on a second call' do
+      post :ensure_api_key, params: { url: 'live.example.com' }, format: :json
+      first_token = JSON.parse(response.body).dig('meta', 'public_api_key', 'token')
+
+      post :ensure_api_key, params: { url: 'live.example.com' }, format: :json
+      second_token = JSON.parse(response.body).dig('meta', 'public_api_key', 'token')
+
+      expect(second_token).to eq(first_token)
+      expect(live_store.api_keys.active.publishable.count).to eq(1)
+    end
+
+    it 'returns not found when no store resolves for the url' do
+      allow(Spree.current_store_finder).to receive(:new).and_return(
+        instance_double(Spree.current_store_finder, execute: nil)
+      )
+
+      post :ensure_api_key, params: { url: 'missing.example.com' }, format: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body).dig('meta', 'status')).to eq('not_found')
+    end
+  end
 end

--- a/spec/services/spree/olitt/clone_store/store_api_key_provisioner_spec.rb
+++ b/spec/services/spree/olitt/clone_store/store_api_key_provisioner_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Spree::Olitt::CloneStore::StoreApiKeyProvisioner do
+  describe '.call' do
+    let(:store) do
+      create(:store, default: false, url: 'shop.example.com', code: 'shop-store')
+    end
+
+    it 'creates a publishable api key when the store has none' do
+      expect(store.api_keys.active.publishable.count).to eq(0)
+
+      api_key = described_class.call(store)
+
+      expect(api_key).to be_present
+      expect(api_key.key_type).to eq('publishable')
+      expect(api_key.store_id).to eq(store.id)
+      expect(store.api_keys.active.publishable.count).to eq(1)
+    end
+
+    it 'returns the existing key instead of creating a second one' do
+      first_key = described_class.call(store)
+      second_key = described_class.call(store)
+
+      expect(second_key.id).to eq(first_key.id)
+      expect(store.api_keys.active.publishable.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Shops cloned by the stale worker (v2.1.5, before May 12) have no publishable API key ->  Storefront shows "Something went wrong."

This PR adds `POST /api/v2/platform/clone-store/ensure-api-key`.

Send it a storefront URL, get back the resolved store's id and publishable API key (minted on demand if missing).

## Why

The prod Sidekiq worker ran v2.1.5 (commit `ad7663f`) from April 11 through. That version had no key-minting step when cloning. All shops cloned in that window have a Spree store but no API key → "Something went wrong." on the storefront.

Re-polling the existing `/clone-store/:id` endpoint cannot fix these shops, the clone job finished. We need ed a side-channel mint. This endpoint is that side-channel, called by Olitt's reconciliation task.

## Behaviour

| Scenario | Response |
|---|---|
| URL resolves to a store, key already exists | `200` — returns existing key unchanged |
| URL resolves to a store, no key yet | `200` — creates key, returns it |
| URL doesn't resolve to any store | `404, `errors: ["Store not found..."]` |

## Design notes

- **Same store finder as the storefront** (`Spree.current_store_finder`), guarantees we mint on the store customers actually hit, automatically handling the duplicate-store case.
- **`StoreApiKeyProvisioner` is a new standalone service**, deliberately does not refactor `CloneRequestProvisioner#ensure_public_api_key!` to mitigate risk of breaking the working clone path.
- **Payload shape** matches the existing clone-status response (`data.id`, `meta.status`, `meta.public_api_key.token/store_id`) so Olitt's existing parser needs no changes.

## Files changed

- `config/routes.rb` -- one new route
- `app/services/spree/olitt/clone_store/store_api_key_provisioner.rb` -- new
- `app/controllers/spree/api/v2/platform/clone_stores_controller.rb` --new action + 4 private helpers
- `spec/services/.../store_api_key_provisioner_spec.rb` -- new
- `spec/controllers/.../clone_stores_controller_spec.rb` -- new describe block
