### PR TITLE
feat(clone): gate category cloning behind CLONE_CATEGORIES_ENABLED

### DIFF
--- a/app/services/spree/olitt/clone_store/store_clone_runner.rb
+++ b/app/services/spree/olitt/clone_store/store_clone_runner.rb
@@ -53,8 +53,6 @@ module Spree
             new_store: @new_store,
             vendor: @vendor
           )
-          run_section('taxonomies', taxonomies_duplicator) { taxonomies_duplicator.handle_clone_taxonomies }
-
           taxon_duplicator = Duplicators::TaxonsDuplicator.new(
             old_store: @old_store,
             new_store: @new_store,
@@ -62,7 +60,10 @@ module Spree
             taxonomies_cache: taxonomies_duplicator.taxonomies_cache,
             root_taxons: taxonomies_duplicator.root_taxons
           )
-          run_section('taxons', taxon_duplicator) { taxon_duplicator.handle_clone_taxons }
+          if clone_categories_enabled?
+            run_section('taxonomies', taxonomies_duplicator) { taxonomies_duplicator.handle_clone_taxonomies }
+            run_section('taxons', taxon_duplicator) { taxon_duplicator.handle_clone_taxons }
+          end
           linked_resource.taxons_cache = taxon_duplicator.taxons_cache
 
           page_duplicator = Duplicators::PagesDuplicator.new(
@@ -172,6 +173,10 @@ module Spree
           end
 
           @new_store.save!
+        end
+
+        def clone_categories_enabled?
+          ENV.fetch('CLONE_CATEGORIES_ENABLED', 'true') != 'false'
         end
 
         def run_section(section_name, duplicator = nil)

--- a/spec/services/spree/olitt/clone_store/store_clone_runner_spec.rb
+++ b/spec/services/spree/olitt/clone_store/store_clone_runner_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+module Spree
+  module Olitt
+    module CloneStore
+      describe StoreCloneRunner do
+        describe '#call category cloning gate' do
+          let(:old_store) { instance_double('Spree::Store') }
+          let(:new_store) { instance_double('Spree::Store') }
+          let(:vendor) { instance_double('Spree::Vendor') }
+          let(:taxonomies_duplicator) { instance_double(Duplicators::TaxonomiesDuplicator).as_null_object }
+          let(:taxons_duplicator) { instance_double(Duplicators::TaxonsDuplicator).as_null_object }
+
+          before do
+            allow(Duplicators::LinkedResourceDuplicator).to receive(:new).and_return(instance_double(Duplicators::LinkedResourceDuplicator).as_null_object)
+            allow(Duplicators::StockLocationsDuplicator).to receive(:new).and_return(instance_double(Duplicators::StockLocationsDuplicator).as_null_object)
+            allow(Duplicators::VendorAddressesDuplicator).to receive(:new).and_return(instance_double(Duplicators::VendorAddressesDuplicator).as_null_object)
+            allow(Duplicators::TaxonomiesDuplicator).to receive(:new).and_return(taxonomies_duplicator)
+            allow(Duplicators::TaxonsDuplicator).to receive(:new).and_return(taxons_duplicator)
+            allow(Duplicators::PagesDuplicator).to receive(:new).and_return(instance_double(Duplicators::PagesDuplicator).as_null_object)
+            allow(Duplicators::ShippingCategoriesDuplicator).to receive(:new).and_return(instance_double(Duplicators::ShippingCategoriesDuplicator).as_null_object)
+            allow(Duplicators::OptionTypesDuplicator).to receive(:new).and_return(instance_double(Duplicators::OptionTypesDuplicator).as_null_object)
+            allow(Duplicators::ProductsDuplicator).to receive(:new).and_return(instance_double(Duplicators::ProductsDuplicator).as_null_object)
+            allow(Duplicators::StockItemsDuplicator).to receive(:new).and_return(instance_double(Duplicators::StockItemsDuplicator).as_null_object)
+            allow(Duplicators::SectionsDuplicator).to receive(:new).and_return(instance_double(Duplicators::SectionsDuplicator).as_null_object)
+            allow(Duplicators::MenusDuplicator).to receive(:new).and_return(instance_double(Duplicators::MenusDuplicator).as_null_object)
+            allow(Duplicators::MenuItemsDuplicator).to receive(:new).and_return(instance_double(Duplicators::MenuItemsDuplicator).as_null_object)
+            allow(Duplicators::PaymentMethodsDuplicator).to receive(:new).and_return(instance_double(Duplicators::PaymentMethodsDuplicator).as_null_object)
+            allow(Duplicators::ShippingMethodsDuplicator).to receive(:new).and_return(instance_double(Duplicators::ShippingMethodsDuplicator).as_null_object)
+            allow(ZoneResolver).to receive(:new).and_return(instance_double(ZoneResolver))
+          end
+
+          def run
+            runner = described_class.new(old_store: old_store, new_store: new_store, vendor: vendor)
+            allow(runner).to receive(:attach_store_images)
+            runner.call
+          end
+
+          context 'when CLONE_CATEGORIES_ENABLED is unset (default)' do
+            before { allow(ENV).to receive(:fetch).and_call_original }
+
+            it 'clones taxonomies and taxons' do
+              run
+
+              expect(taxonomies_duplicator).to have_received(:handle_clone_taxonomies)
+              expect(taxons_duplicator).to have_received(:handle_clone_taxons)
+            end
+          end
+
+          context "when CLONE_CATEGORIES_ENABLED is 'false'" do
+            before do
+              allow(ENV).to receive(:fetch).and_call_original
+              allow(ENV).to receive(:fetch).with('CLONE_CATEGORIES_ENABLED', 'true').and_return('false')
+            end
+
+            it 'skips taxonomy and taxon cloning' do
+              run
+
+              expect(taxonomies_duplicator).not_to have_received(:handle_clone_taxonomies)
+              expect(taxons_duplicator).not_to have_received(:handle_clone_taxons)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this solves
Every AI-generated shop shows several sets of categories (Categories,
Collections, Categories 2) in the storefront menu and footer. It reads as
broken and clutters the shop.

"Categories" in Spree are taxonomies/taxons. A new Spree store seeds no
taxonomies of its own (the built-in seeder is deprecated and unwired), so
the only source of a shop's categories is the clone: StoreCloneRunner's
TaxonomiesDuplicator copies every taxonomy from the template store
verbatim. 

Taxonomy/taxon cloning ran unconditionally in StoreCloneRunner, with no
way to turn it off short of editing the template store (which we don't
want to require).

## Solution
Gate the taxonomy and taxon duplicators behind a new
`CLONE_CATEGORIES_ENABLED` environment variable, mirroring the existing
`PRODUCTS_CLONE_LIMIT` pattern. It defaults to enabled, so behavior is
unchanged until an environment sets `CLONE_CATEGORIES_ENABLED=false`,
which makes newly cloned shops skip the inherited category trees.

The clone runs inside CloneStoreJob (Sidekiq), so the variable is read in
the worker environment. Product ->taxon links cannot be orphaned: the taxon
cache is left empty when gated and the product duplicator reads it
null-safely (and in production PRODUCTS_CLONE_LIMIT=0 means no products
clone anyway).